### PR TITLE
Add qt5-quickcontrols2 to installed packages

### DIFF
--- a/os/qml/setup-system
+++ b/os/qml/setup-system
@@ -20,7 +20,7 @@ sudo pacman -S --needed --noconfirm \
 
 echo " $(tput bold)installing Qt$(tput sgr0)"
 sudo pacman -S --needed --noconfirm \
-  qt5-quickcontrols qt5-webengine
+  qt5-quickcontrols qt5-quickcontrols2 qt5-webengine
 
 # configure 8080 to 80 redirect
 if [ ! -f /etc/systemd/system/localhost-80to8080.service ]; then


### PR DESCRIPTION
QtWebEngine requires QtQuick.Controls version 2.0 via Controls2Delegates/Menu.qml. If not installed, dragging text or opening a context menu inside the WebEngine will cause a crash.